### PR TITLE
Remove YubiKey reader filter

### DIFF
--- a/ykman/_cli/fido.py
+++ b/ykman/_cli/fido.py
@@ -92,7 +92,11 @@ def fido(ctx):
         scp_params = resolve_scp(s_conn)
         conn = SmartCardCtapDevice(s_conn, scp_params)
     else:
-        conn = dev.open_connection(FidoConnection)
+        if dev.supports_connection(FidoConnection):
+            conn = dev.open_connection(FidoConnection)
+        else:
+            s_conn = dev.open_connection(SmartCardConnection)
+            conn = SmartCardCtapDevice(s_conn)
 
     ctx.call_on_close(conn.close)
     ctx.obj["conn"] = conn


### PR DESCRIPTION
## Summary
- relax the PC/SC reader filter so ykman sees non-YubiKey smart cards
- default non-YubiKey readers to PID.YK4_CCID and mark as USB
- fall back to a smart card connection for FIDO commands when USB isn't supported
- allow missing PIV metadata fields so PivApplet works
- handle truncated retry metadata for PIN/PUK operations
- treat unrecognized metadata commands as unsupported
- fix typo in biometric unsupported message

## Testing
- `pip install -q cryptography pyscard fido2 click keyring makefun` *(fails: building pyscard)*
- `pytest -q` *(fails: missing cryptography/fido2 dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_6842920220f08326bb268ee71753916f